### PR TITLE
fix: remove md5

### DIFF
--- a/data/tables/car.js
+++ b/data/tables/car.js
@@ -40,7 +40,6 @@ export function createCarTable (region, tableName, options = {}) {
               size: { 'N': `${car.size}`},
               url: { 'S': car.url },
               commP: { 'S': car.commP },
-              md5: { 'S': car.md5 },
               insertedAt: { 'S': insertedAt },
             },
             ConditionExpression: 'attribute_not_exists(link)',

--- a/data/tables/index.js
+++ b/data/tables/index.js
@@ -7,7 +7,6 @@ export const carTableProps = {
     size: 'number',         // `101`
     url: 'string',        // `https://...`
     commP: 'string',       // `commP...a`
-    md5: 'string',       // `md5...a`
     insertedAt: 'string',   // `2023-01-17T...`
   },
   // link
@@ -21,7 +20,7 @@ export const ferryTableProps = {
     size: 'number',         // `101`
     // Note: `state` and `status` are reserved keywords in dynamodb
     stat: 'string',        // 'LOADING' | 'READY' | 'DEAL_PENDING' | 'DEAL_PROCESSED'
-    commP: 'string',       // `bafy1...a`
+    commP: 'string',       // `commP...a`
     insertedAt: 'string',   // `2023-01-17T...`
   },
   // link

--- a/data/test/tables/car.test.js
+++ b/data/test/tables/car.test.js
@@ -35,7 +35,6 @@ test('can add cars to table uniquely', async (t) => {
     size: car.size,
     commP: 'commP',
     url: 'url',
-    md5: 'md5',
   }))
 
   await carTable.batchWrite(cars)

--- a/data/types.ts
+++ b/data/types.ts
@@ -5,7 +5,6 @@ export interface CarItem {
   size: number
   commP: string
   url: string
-  md5: string
 }
 
 export interface CarItemFerry {

--- a/seed.yml
+++ b/seed.yml
@@ -1,4 +1,4 @@
 
 before_compile:
-  - n 16.17.1
+  - n 18.13.0
   - npm ci

--- a/test/data.test.js
+++ b/test/data.test.js
@@ -251,7 +251,6 @@ async function getBatchesToWrite (length, batchSize) {
         size: car.size,
         commP: 'commP',
         url: 'url',
-        md5: 'md5',
       }))
     })
   )


### PR DESCRIPTION
We do not need md5 anymore. With commP we already have enough info to validate downloaded CAR files integrity as well.