### PR TITLE
fix: conform with aggregation spec namings

### DIFF
--- a/data/tables/car.js
+++ b/data/tables/car.js
@@ -38,8 +38,8 @@ export function createCarTable (region, tableName, options = {}) {
             Item: {
               link: { 'S': car.link },
               size: { 'N': `${car.size}`},
-              url: { 'S': car.url },
-              commP: { 'S': car.commP },
+              src: { 'SS': car.src },
+              commitmentProof: { 'S': car.commitmentProof },
               insertedAt: { 'S': insertedAt },
             },
             ConditionExpression: 'attribute_not_exists(link)',

--- a/data/tables/index.js
+++ b/data/tables/index.js
@@ -5,8 +5,8 @@ export const carTableProps = {
   fields: {
     link: 'string',         // `bagy...1`
     size: 'number',         // `101`
-    url: 'string',        // `https://...`
-    commP: 'string',       // `commP...a`
+    src: 'string',        // `https://...`
+    commitmentProof: 'string',       // `commitmentProof...a`
     insertedAt: 'string',   // `2023-01-17T...`
   },
   // link
@@ -20,7 +20,7 @@ export const ferryTableProps = {
     size: 'number',         // `101`
     // Note: `state` and `status` are reserved keywords in dynamodb
     stat: 'string',        // 'LOADING' | 'READY' | 'DEAL_PENDING' | 'DEAL_PROCESSED'
-    commP: 'string',       // `commP...a`
+    commitmentProof: 'string',       // `commitmentProof...a`
     insertedAt: 'string',   // `2023-01-17T...`
   },
   // link

--- a/data/test/tables/car.test.js
+++ b/data/test/tables/car.test.js
@@ -33,8 +33,8 @@ test('can add cars to table uniquely', async (t) => {
   const cars = (await getCars(10)).map(car => ({
     link: car.link.toString(),
     size: car.size,
-    commP: 'commP',
-    url: 'url',
+    commitmentProof: 'commitmentProof',
+    src: ['url'],
   }))
 
   await carTable.batchWrite(cars)

--- a/data/types.ts
+++ b/data/types.ts
@@ -3,8 +3,8 @@ export type FerryState = 'LOADING' | 'READY' | 'DEAL_PENDING' | 'DEAL_PROCESSED'
 export interface CarItem {
   link: string
   size: number
-  commP: string
-  url: string
+  commitmentProof: string
+  src: string[]
 }
 
 export interface CarItemFerry {

--- a/test/data.test.js
+++ b/test/data.test.js
@@ -249,8 +249,8 @@ async function getBatchesToWrite (length, batchSize) {
       return cars.map(car => ({
         link: car.link.toString(),
         size: car.size,
-        commP: 'commP',
-        url: 'url',
+        commitmentProof: 'commitmentProof',
+        src: ['url'],
       }))
     })
   )


### PR DESCRIPTION
in spec we support src as array of URLs and we call `commitmentProof` instead of `commP`. Let's make these changes here as well