### PR TITLE
fix: aggregate add self invocation and standard queue grouping

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6407,9 +6407,9 @@
       }
     },
     "node_modules/@web3-storage/filecoin-api": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@web3-storage/filecoin-api/-/filecoin-api-1.4.0.tgz",
-      "integrity": "sha512-qydYy5dVoqvJ/UNO7LkNEzhKf4UeFElwevDqknYyVTUjgXOPTM89zWbbm+txbXljSTsf3yNMgancKdWIv9N+5g==",
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/@web3-storage/filecoin-api/-/filecoin-api-1.4.4.tgz",
+      "integrity": "sha512-P5k1FJtjZnojCpryCMnwjiE2fhdTW2L/PrdHsn8J/EeVcR8OVmDITrxbLYg9dd0jh9ElAsz/JqAKSrrO08UCpA==",
       "dependencies": {
         "@ipld/dag-ucan": "^3.3.2",
         "@ucanto/client": "^8.0.0",
@@ -17207,7 +17207,7 @@
         "@ucanto/transport": "^8.0.0",
         "@web3-storage/capabilities": "^9.2.1",
         "@web3-storage/data-segment": "^3.0.1",
-        "@web3-storage/filecoin-api": "^1.4.0",
+        "@web3-storage/filecoin-api": "^1.4.4",
         "@web3-storage/filecoin-client": "^1.3.0",
         "multiformats": "12.0.1",
         "p-retry": "^5.1.2",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -19,7 +19,7 @@
     "@ucanto/transport": "^8.0.0",
     "@web3-storage/capabilities": "^9.2.1",
     "@web3-storage/data-segment": "^3.0.1",
-    "@web3-storage/filecoin-api": "^1.4.0",
+    "@web3-storage/filecoin-api": "^1.4.4",
     "@web3-storage/filecoin-client": "^1.3.0",
     "multiformats": "12.0.1",
     "uint8arrays": "^4.0.4",
@@ -41,6 +41,7 @@
   },
   "eslintConfig": {
     "rules": {
+      "unicorn/no-array-reduce": "off",
       "unicorn/no-for-loop": "off",
       "unicorn/no-null": "off",
       "unicorn/no-useless-promise-resolve-reject": "off",

--- a/packages/core/src/utils.js
+++ b/packages/core/src/utils.js
@@ -1,0 +1,8 @@
+
+/**
+ * @param {string} storefront
+ * @param {string} group
+ */
+export function getMessageGroupId (storefront, group) {
+  return `${storefront}:${group}`
+}

--- a/packages/core/src/workflow/piece-add.js
+++ b/packages/core/src/workflow/piece-add.js
@@ -1,0 +1,128 @@
+import { Aggregator } from '@web3-storage/filecoin-client'
+import * as Server from '@ucanto/server'
+import { decode as decodePiece } from '../data/piece.js'
+
+/**
+ * @typedef {import('@web3-storage/data-segment').PieceLink} PieceLink
+ * @typedef {import('../data/types.js').Piece<PieceLink>} Piece
+ * 
+ * @typedef {object} EncodedRecord
+ * @property {string} body
+ * @property {string} id
+ * 
+ * @typedef {object} Record
+ * @property {Piece} piece
+ * @property {string} id
+ */
+
+/**
+ * Invokes aggregate/add on the queued system to go through the backlog of pieces provided by Storefront actors.
+ * Once the `aggregate/add` succeeds, the peice is queued for buffering on its way to be aggregated.
+ * When only a subset of the pieces succeed, a `batchItemFailures` is returned so that these items can be re-queued.
+ *
+ * @param {object} props
+ * @param {import('@web3-storage/filecoin-api/types').Queue<Piece>} props.queueClient
+ * @param {import('@web3-storage/filecoin-client/types').InvocationConfig} props.invocationConfig
+ * @param {import('@ucanto/principal/ed25519').ConnectionView<any>} props.aggregatorServiceConnection
+ * @param {EncodedRecord[]} props.records - message encoded piece records
+ */
+export async function addPieces ({
+  queueClient,
+  invocationConfig,
+  aggregatorServiceConnection,
+  records,
+}) {
+  const decodedRecords = await Promise.all(
+    records.map(async pr => ({
+      piece: await decodePiece.message(pr.body),
+      id: pr.id
+    }))
+  )
+
+  let responses
+  try {
+    responses = await Promise.all(
+      decodedRecords.map(record => addPiece({
+        queueClient,
+        invocationConfig,
+        aggregatorServiceConnection,
+        record
+      }))
+    )
+  } catch {
+    return {
+      error: new AggregateAddFailed('failed to add pieces')
+    }
+  }
+
+  return {
+    ok: {
+      // number of successful handled pieces
+      countSuccess: responses.reduce((acc, value) => {
+        return value.ok ? acc + 1 : acc
+      }, 0),
+      // failed pieces that can be re-queued
+      batchItemFailures: responses.reduce((filtered, value) => {
+        if (value.error) {
+          filtered.push(value.id)
+        }
+
+        return filtered
+      }, /** @type {string[]} */ ([]))
+    }
+  }
+}
+
+/**
+ * @param {object} props
+ * @param {import('@web3-storage/filecoin-api/types').Queue<Piece>} props.queueClient
+ * @param {import('@web3-storage/filecoin-client/types').InvocationConfig} props.invocationConfig
+ * @param {import('@ucanto/principal/ed25519').ConnectionView<any>} props.aggregatorServiceConnection
+ * @param {Record} props.record 
+ */
+async function addPiece ({
+  queueClient,
+  invocationConfig,
+  aggregatorServiceConnection,
+  record
+}) {
+  const aggregateAddResponse = await Aggregator.aggregateAdd(
+    invocationConfig,
+    record.piece.piece,
+    record.piece.storefront,
+    record.piece.group,
+    { connection: aggregatorServiceConnection }
+  )
+  if (aggregateAddResponse.out.error) {
+    return {
+      id: record.id,
+      error: aggregateAddResponse.out.error
+    }
+  }
+
+  const queueAddResponse = await queueClient.add(record.piece)
+  if (queueAddResponse.error) {
+    return {
+      id: record.id,
+      error: queueAddResponse.error
+    }
+  }
+
+  return {
+    id: record.id,
+    ok: {}
+  }
+}
+
+export const AggregateAddErrorName = /** @type {const} */ (
+  'AggregateAddFailed'
+)
+export class AggregateAddFailed extends Server.Failure {
+  get reason() {
+    return this.message
+  }
+
+  get name() {
+    return AggregateAddErrorName
+  }
+}

--- a/packages/core/src/workflow/piece-buffering.js
+++ b/packages/core/src/workflow/piece-buffering.js
@@ -1,173 +1,58 @@
-import * as Server from '@ucanto/server'
-
 import { decode as decodePiece } from '../data/piece.js'
-import { getMessageGroupId } from '../utils.js'
 
 /**
  * @typedef {import('@web3-storage/data-segment').PieceLink} PieceLink
- * @typedef {import('../data/types.js').Piece<PieceLink>} Piece
  * @typedef {import('../data/types.js').Buffer<PieceLink>} Data
  * @typedef {import('../data/types.js').PiecePolicy} PiecePolicy
- * 
- * @typedef {object} EncodedRecord
- * @property {string} body
- * @property {string} id
- * 
- * @typedef {object} Record
- * @property {Piece} piece
- * @property {string} id
  */
 
 /**
  * @param {object} props
  * @param {import('@web3-storage/filecoin-api/types').Store<Data>} props.storeClient 
  * @param {import('@web3-storage/filecoin-api/types').Queue<Data>} props.queueClient
- * @param {EncodedRecord[]} props.records - message encoded piece records
- * @param {boolean} [props.disableMessageGroupId] - only supported in FIFO queues
+ * @param {string[]} props.pieceRecords
+ * @param {string} [props.groupId]
  */
 export async function bufferPieces ({
   storeClient,
   queueClient,
-  records,
-  disableMessageGroupId,
-}) {
-  // Decode records
-  const decodedRecords = await Promise.all(
-    records.map(async r => ({
-      piece: await decodePiece.message(r.body),
-      id: r.id
-    }))
-  )
-
-  // Split records by the group they belong to
-  const groupedRecords = groupByStorefrontIdentifier(decodedRecords)
-
-  // Buffer records by groups
-  let responses
-  try {
-    responses = await Promise.all(
-      [...groupedRecords.entries()].map(([messageGroupId, records]) => bufferGroupPieces({
-        storeClient,
-        queueClient,
-        records,
-        messageGroupId: disableMessageGroupId ? undefined : messageGroupId
-      }))
-    )
-  } catch {
-    return {
-      error: new PieceBufferingFailed('failed to buffer given pieces')
-    }
-  }
-
-  // number of successful handled pieces
-  const countSuccess = responses.reduce((acc, value) => {
-    return value.ok ? acc + value.ok : acc
-  }, 0)
-
-  // Send back first error given no partial success was achieved
-  if (!countSuccess) {
-    return {
-      error: responses.find(r => r.error)?.error || new PieceBufferingFailed()
-    }
-  }
-
-  return {
-    ok: {
-      countSuccess,
-      // failed pieces that can be re-queued
-      batchItemFailures: responses.reduce((conc, value) => {
-        if (value.error) {
-          conc = [
-            ...conc,
-            ...value.batchItemFailures
-          ]
-        }
-
-        return conc
-      }, /** @type {string[]} */ ([]))
-    }
-  }
-}
-
-/**
- * @param {object} props
- * @param {import('@web3-storage/filecoin-api/types').Store<Data>} props.storeClient 
- * @param {import('@web3-storage/filecoin-api/types').Queue<Data>} props.queueClient
- * @param {Record[]} props.records
- * @param {string} [props.messageGroupId]
- */
-async function bufferGroupPieces ({
-  storeClient,
-  queueClient,
-  records,
-  messageGroupId,
+  pieceRecords,
+  groupId
 }) {
   // Get storefront and group from one of the pieces
   // per grouping, all of them are the same
-  const { storefront, group } = records[0].piece
+  const { storefront, group } = await decodePiece.message(pieceRecords[0])
 
   // Create buffer
   const buffer = {
-    pieces: records.map(r => ({
-      ...r.piece,
-      // set policy as insertion
-      policy: /** @type {PiecePolicy} */ (0)
-    })).sort(),
+    pieces: (await Promise.all(pieceRecords.map(async (piece) => {
+      const entry = await decodePiece.message(piece)
+      return {
+        ...entry,
+        // set policy as insertion
+        policy: /** @type {PiecePolicy} */ (0)
+      }
+    }))),
     storefront,
     group
   }
-
   const bufferStored = await storeClient.put(buffer)
   if (bufferStored.error) {
     return {
-      batchItemFailures: records.map(r => r.id),
       error: bufferStored.error
     }
   }
-  const bufferQueued = await queueClient.add(buffer, {
-    // only available in FIFO queues
-    messageGroupId
-  })
 
+  const bufferQueued = await queueClient.add(buffer, {
+    messageGroupId: groupId
+  })
   if (bufferQueued.error) {
     return {
-      batchItemFailures: records.map(r => r.id),
       error: bufferQueued.error
     }
   }
   
   return {
-    ok: records.length,
-  }
-}
-
-/**
- * only FIFO queues allow message group id, so we need to split them here.
- *
- * @param {Record[]} records
- */
-function groupByStorefrontIdentifier (records) {
-  return records.reduce((acc, cur) => {
-    const messageGroupId = getMessageGroupId(cur.piece.storefront, cur.piece.group)
-
-    acc.set(messageGroupId, [
-      ...acc.get(messageGroupId) || [],
-      cur
-    ])
-
-    return acc
-  }, /** @type {Map<string, Record[]>} */ (new Map()))
-}
-
-export const PieceBufferingErrorName = /** @type {const} */ (
-  'PieceBufferingFailed'
-)
-export class PieceBufferingFailed extends Server.Failure {
-  get reason() {
-    return this.message
-  }
-
-  get name() {
-    return PieceBufferingErrorName
+    ok: pieceRecords.length
   }
 }

--- a/packages/core/src/workflow/piece-buffering.js
+++ b/packages/core/src/workflow/piece-buffering.js
@@ -1,59 +1,173 @@
+import * as Server from '@ucanto/server'
+
 import { decode as decodePiece } from '../data/piece.js'
+import { getMessageGroupId } from '../utils.js'
 
 /**
  * @typedef {import('@web3-storage/data-segment').PieceLink} PieceLink
+ * @typedef {import('../data/types.js').Piece<PieceLink>} Piece
  * @typedef {import('../data/types.js').Buffer<PieceLink>} Data
  * @typedef {import('../data/types.js').PiecePolicy} PiecePolicy
+ * 
+ * @typedef {object} EncodedRecord
+ * @property {string} body
+ * @property {string} id
+ * 
+ * @typedef {object} Record
+ * @property {Piece} piece
+ * @property {string} id
  */
 
 /**
  * @param {object} props
  * @param {import('@web3-storage/filecoin-api/types').Store<Data>} props.storeClient 
  * @param {import('@web3-storage/filecoin-api/types').Queue<Data>} props.queueClient
- * @param {string[]} props.pieceRecords 
- * @param {string} [props.groupId]
+ * @param {EncodedRecord[]} props.records - message encoded piece records
+ * @param {boolean} [props.disableMessageGroupId] - only supported in FIFO queues
  */
 export async function bufferPieces ({
   storeClient,
   queueClient,
-  pieceRecords,
-  groupId
+  records,
+  disableMessageGroupId,
 }) {
-  // Get storefront and group from one of the pieces
-  // per grouping, all of them are the same
-  const { storefront, group } = await decodePiece.message(pieceRecords[0])
+  // Decode records
+  const decodedRecords = await Promise.all(
+    records.map(async r => ({
+      piece: await decodePiece.message(r.body),
+      id: r.id
+    }))
+  )
 
-  // Create buffer
-  const buffer = {
-    pieces: (await Promise.all(pieceRecords.map(async (piece) => {
-      const entry = await decodePiece.message(piece)
-      return {
-        ...entry,
-        // set policy as insertion
-        policy: /** @type {PiecePolicy} */ (0)
-      }
-      // TODO: we need to sort by size
-    }))).sort(),
-    storefront,
-    group
-  }
-  const bufferStored = await storeClient.put(buffer)
-  if (bufferStored.error) {
+  // Split records by the group they belong to
+  const groupedRecords = groupByStorefrontIdentifier(decodedRecords)
+
+  // Buffer records by groups
+  let responses
+  try {
+    responses = await Promise.all(
+      [...groupedRecords.entries()].map(([messageGroupId, records]) => bufferGroupPieces({
+        storeClient,
+        queueClient,
+        records,
+        messageGroupId: disableMessageGroupId ? undefined : messageGroupId
+      }))
+    )
+  } catch {
     return {
-      error: bufferStored.error
+      error: new PieceBufferingFailed('failed to buffer given pieces')
     }
   }
 
+  // number of successful handled pieces
+  const countSuccess = responses.reduce((acc, value) => {
+    return value.ok ? acc + value.ok : acc
+  }, 0)
+
+  // Send back first error given no partial success was achieved
+  if (!countSuccess) {
+    return {
+      error: responses.find(r => r.error)?.error || new PieceBufferingFailed()
+    }
+  }
+
+  return {
+    ok: {
+      countSuccess,
+      // failed pieces that can be re-queued
+      batchItemFailures: responses.reduce((conc, value) => {
+        if (value.error) {
+          conc = [
+            ...conc,
+            ...value.batchItemFailures
+          ]
+        }
+
+        return conc
+      }, /** @type {string[]} */ ([]))
+    }
+  }
+}
+
+/**
+ * @param {object} props
+ * @param {import('@web3-storage/filecoin-api/types').Store<Data>} props.storeClient 
+ * @param {import('@web3-storage/filecoin-api/types').Queue<Data>} props.queueClient
+ * @param {Record[]} props.records
+ * @param {string} [props.messageGroupId]
+ */
+async function bufferGroupPieces ({
+  storeClient,
+  queueClient,
+  records,
+  messageGroupId,
+}) {
+  // Get storefront and group from one of the pieces
+  // per grouping, all of them are the same
+  const { storefront, group } = records[0].piece
+
+  // Create buffer
+  const buffer = {
+    pieces: records.map(r => ({
+      ...r.piece,
+      // set policy as insertion
+      policy: /** @type {PiecePolicy} */ (0)
+    })).sort(),
+    storefront,
+    group
+  }
+
+  const bufferStored = await storeClient.put(buffer)
+  if (bufferStored.error) {
+    return {
+      batchItemFailures: records.map(r => r.id),
+      error: bufferStored.error
+    }
+  }
   const bufferQueued = await queueClient.add(buffer, {
-    messageGroupId: groupId
+    // only available in FIFO queues
+    messageGroupId
   })
+
   if (bufferQueued.error) {
     return {
+      batchItemFailures: records.map(r => r.id),
       error: bufferQueued.error
     }
   }
   
   return {
-    ok: pieceRecords.length
+    ok: records.length,
+  }
+}
+
+/**
+ * only FIFO queues allow message group id, so we need to split them here.
+ *
+ * @param {Record[]} records
+ */
+function groupByStorefrontIdentifier (records) {
+  return records.reduce((acc, cur) => {
+    const messageGroupId = getMessageGroupId(cur.piece.storefront, cur.piece.group)
+
+    acc.set(messageGroupId, [
+      ...acc.get(messageGroupId) || [],
+      cur
+    ])
+
+    return acc
+  }, /** @type {Map<string, Record[]>} */ (new Map()))
+}
+
+export const PieceBufferingErrorName = /** @type {const} */ (
+  'PieceBufferingFailed'
+)
+export class PieceBufferingFailed extends Server.Failure {
+  get reason() {
+    return this.message
+  }
+
+  get name() {
+    return PieceBufferingErrorName
   }
 }

--- a/packages/core/test/helpers/mocks.js
+++ b/packages/core/test/helpers/mocks.js
@@ -6,14 +6,20 @@ const notImplemented = () => {
 
 /**
  * @param {Partial<
+ * import('@web3-storage/filecoin-client/types').AggregatorService &
  * import('@web3-storage/filecoin-client/types').DealerService
  * >} impl
  */
 export function mockService(impl) {
  return {
-   deal: {
-     add: withCallCount(impl.deal?.add ?? notImplemented),
-   },
+  deal: {
+    add: withCallCount(impl.deal?.add ?? notImplemented),
+    queue: withCallCount(impl.deal?.queue ?? notImplemented),
+  },
+  aggregate: {
+   add: withCallCount(impl.aggregate?.add ?? notImplemented),
+   queue: withCallCount(impl.aggregate?.queue ?? notImplemented),
+ },
  }
 }
 

--- a/packages/core/test/workflow/piece-add.test.js
+++ b/packages/core/test/workflow/piece-add.test.js
@@ -74,8 +74,6 @@ test('can add received pieces', async t => {
 
   t.truthy(aggregatorAddResp.ok)
   t.falsy(aggregatorAddResp.error)
-  t.is(aggregatorAddResp.ok?.countSuccess, pieces.length)
-  t.deepEqual(aggregatorAddResp.ok?.batchItemFailures, [])
 
   // Validate messages received to queue
   await pWaitFor(() => queuedMessages.length === pieces.length)
@@ -127,8 +125,6 @@ test('handles partial fails when received same pieces and fails to add them', as
 
   t.truthy(aggregatorQueueRespA.ok)
   t.falsy(aggregatorQueueRespA.error)
-  t.is(aggregatorQueueRespA.ok?.countSuccess, pieceRecordsA.length)
-  t.deepEqual(aggregatorQueueRespA.ok?.batchItemFailures, [])
 
   // Validate messages received to queue
   await pWaitFor(() => queuedMessages.length === pieceRecordsA.length)
@@ -148,12 +144,11 @@ test('handles partial fails when received same pieces and fails to add them', as
     }))
   })
 
-  t.truthy(aggregatorQueueRespB.ok)
-  t.falsy(aggregatorQueueRespB.error)
-  t.is(aggregatorQueueRespB.ok?.countSuccess, pieces.length - pieceRecordsA.length)
-  t.is(aggregatorQueueRespB.ok?.batchItemFailures.length, (pieceRecordsB.length + pieceRecordsA.length) - pieces.length)
+  t.falsy(aggregatorQueueRespB.ok)
+  t.truthy(aggregatorQueueRespB.error)
+  t.is(aggregatorQueueRespB.error?.length, (pieceRecordsB.length + pieceRecordsA.length) - pieces.length)
   t.deepEqual(
-    aggregatorQueueRespB.ok?.batchItemFailures,
+    aggregatorQueueRespB.error?.map(e => e?.id),
     Array.from({ length: (pieceRecordsB.length + pieceRecordsA.length) - pieces.length }, (_, i) => `${i}`)
   )
 
@@ -189,12 +184,11 @@ test('handles failures when received same pieces and fails to queue them for buf
     }))
   })
 
-  t.truthy(aggregatorQueueResp.ok)
-  t.falsy(aggregatorQueueResp.error)
-  t.is(aggregatorQueueResp.ok?.countSuccess, 0)
-  t.is(aggregatorQueueResp.ok?.batchItemFailures.length, pieces.length)
+  t.falsy(aggregatorQueueResp.ok)
+  t.truthy(aggregatorQueueResp.error)
+  t.is(aggregatorQueueResp.error?.length, pieces.length)
   t.deepEqual(
-    aggregatorQueueResp.ok?.batchItemFailures,
+    aggregatorQueueResp.error?.map(e => e?.id),
     Array.from({ length: pieces.length }, (_, i) => `${i}`)
   )
 })

--- a/packages/core/test/workflow/piece-add.test.js
+++ b/packages/core/test/workflow/piece-add.test.js
@@ -1,0 +1,258 @@
+import { tesWorkflow as test } from '../helpers/context.js'
+import { createQueue } from '../helpers/resources.js'
+import { randomCargo } from '../helpers/cargo.js'
+import { getAggregatorServiceServer, getAggregatorServiceCtx } from '../helpers/ucanto.js'
+
+import { Consumer } from 'sqs-consumer'
+import pWaitFor from 'p-wait-for'
+import delay from 'delay'
+import pDefer from 'p-defer'
+import { QueueOperationFailed } from '@web3-storage/filecoin-api/errors'
+
+import { getServiceSigner } from '../../src/service.js'
+import { encode as pieceEncode } from '../../src/data/piece.js'
+import { createQueueClient } from '../../src/queue/client.js'
+
+import { addPieces } from '../../src/workflow/piece-add.js'
+
+test.beforeEach(async (t) => {
+  const sqs = await createQueue()
+
+  /** @type {import('@aws-sdk/client-sqs').Message[]} */
+  const queuedMessages = []
+  const queueConsumer = Consumer.create({
+    queueUrl: sqs.queueUrl,
+    sqs: sqs.client,
+    handleMessage: (message) => {
+      queuedMessages.push(message)
+      return Promise.resolve()
+    }
+  })
+
+  Object.assign(t.context, {
+    sqsClient: sqs.client,
+    queueName: sqs.queueName,
+    queueUrl: sqs.queueUrl,
+    queueConsumer,
+    queuedMessages
+  })
+})
+
+test.beforeEach(async t => {
+  t.context.queueConsumer.start()
+  await pWaitFor(() => t.context.queueConsumer.isRunning)
+})
+
+test.afterEach(async t => {
+  t.context.queueConsumer.stop()
+  await delay(1000)
+})
+
+test('can add received pieces', async t => {
+  const { sqsClient, queueUrl, queuedMessages } = t.context
+
+  const { pieces, pieceRecords } = await getPieces(10, 128)
+  const queueClient = createQueueClient(sqsClient, {
+    queueUrl,
+    encodeMessage: pieceEncode.message,
+  })
+
+  const aggregatorAddCall = pDefer()
+  const { invocationConfig, aggregatorService } = await getService({
+    onCall: aggregatorAddCall
+  })
+
+  const aggregatorAddResp = await addPieces({
+    queueClient,
+    invocationConfig,
+    aggregatorServiceConnection: aggregatorService.connection,
+    records: pieceRecords.map((pr, index) => ({
+      body: pr,
+      id: `${index}`
+    }))
+  })
+
+  t.truthy(aggregatorAddResp.ok)
+  t.falsy(aggregatorAddResp.error)
+  t.is(aggregatorAddResp.ok?.countSuccess, pieces.length)
+  t.deepEqual(aggregatorAddResp.ok?.batchItemFailures, [])
+
+  // Validate messages received to queue
+  await pWaitFor(() => queuedMessages.length === pieces.length)
+
+  // Validate ucanto server call
+  const invCap = await aggregatorAddCall.promise
+  t.is(aggregatorService.service.aggregate.add.callCount, pieces.length)
+  t.is(invCap.can, 'aggregate/add')
+})
+
+test('handles partial fails when received same pieces and fails to add them', async t => {
+  const { sqsClient, queueUrl, queuedMessages } = t.context
+
+  const { pieces, pieceRecords } = await getPieces(10, 128)
+  // Creating two slices of pieces with common intersection - 2 pieces
+  const pieceRecordsA = pieceRecords.slice(0, (pieceRecords.length / 2) + 1)
+  const pieceRecordsB = pieceRecords.slice((pieceRecords.length / 2) - 1)
+
+  // Create context
+  const queueClient = createQueueClient(sqsClient, {
+    queueUrl,
+    encodeMessage: pieceEncode.message,
+  })
+
+  const seenPieces = new Set()
+  const aggregatorAddCall = pDefer()
+  const { invocationConfig, aggregatorService } = await getService({
+    onCall: aggregatorAddCall,
+    // Fails if it already has piece
+    shouldFail: (invCap) => {
+      const pieceString = invCap.nb.piece.toString()
+      if (seenPieces.has(pieceString)) {
+        return true
+      }
+      seenPieces.add(pieceString)
+      return false
+    }
+  })
+
+  const aggregatorQueueRespA = await addPieces({
+    queueClient,
+    invocationConfig,
+    aggregatorServiceConnection: aggregatorService.connection,
+    records: pieceRecordsA.map((pr, index) => ({
+      body: pr,
+      id: `${index}`
+    }))
+  })
+
+  t.truthy(aggregatorQueueRespA.ok)
+  t.falsy(aggregatorQueueRespA.error)
+  t.is(aggregatorQueueRespA.ok?.countSuccess, pieceRecordsA.length)
+  t.deepEqual(aggregatorQueueRespA.ok?.batchItemFailures, [])
+
+  // Validate messages received to queue
+  await pWaitFor(() => queuedMessages.length === pieceRecordsA.length)
+
+  // Validate ucanto server call
+  const invCap = await aggregatorAddCall.promise
+  t.is(aggregatorService.service.aggregate.add.callCount, pieceRecordsA.length)
+  t.is(invCap.can, 'aggregate/add')
+
+  const aggregatorQueueRespB = await addPieces({
+    queueClient,
+    invocationConfig,
+    aggregatorServiceConnection: aggregatorService.connection,
+    records: pieceRecordsB.map((pr, index) => ({
+      body: pr,
+      id: `${index}`
+    }))
+  })
+
+  t.truthy(aggregatorQueueRespB.ok)
+  t.falsy(aggregatorQueueRespB.error)
+  t.is(aggregatorQueueRespB.ok?.countSuccess, pieces.length - pieceRecordsA.length)
+  t.is(aggregatorQueueRespB.ok?.batchItemFailures.length, (pieceRecordsB.length + pieceRecordsA.length) - pieces.length)
+  t.deepEqual(
+    aggregatorQueueRespB.ok?.batchItemFailures,
+    Array.from({ length: (pieceRecordsB.length + pieceRecordsA.length) - pieces.length }, (_, i) => `${i}`)
+  )
+
+  // Validate messages received to queue
+  await pWaitFor(() => queuedMessages.length === pieces.length)
+})
+
+test('handles failures when received same pieces and fails to queue them for buffering', async t => {
+  const { pieces, pieceRecords } = await getPieces(10, 128)
+
+  // Create context
+  const queueClient = {
+    add: () => {
+      return {
+        error: new QueueOperationFailed('could not queue buffer')
+      }
+    }
+  }
+
+  const aggregatorAddCall = pDefer()
+  const { invocationConfig, aggregatorService } = await getService({
+    onCall: aggregatorAddCall
+  })
+
+  const aggregatorQueueResp = await addPieces({
+    // @ts-expect-error adapted queue
+    queueClient,
+    invocationConfig,
+    aggregatorServiceConnection: aggregatorService.connection,
+    records: pieceRecords.map((pr, index) => ({
+      body: pr,
+      id: `${index}`
+    }))
+  })
+
+  t.truthy(aggregatorQueueResp.ok)
+  t.falsy(aggregatorQueueResp.error)
+  t.is(aggregatorQueueResp.ok?.countSuccess, 0)
+  t.is(aggregatorQueueResp.ok?.batchItemFailures.length, pieces.length)
+  t.deepEqual(
+    aggregatorQueueResp.ok?.batchItemFailures,
+    Array.from({ length: pieces.length }, (_, i) => `${i}`)
+  )
+})
+
+/**
+ * @param {object} options
+ * @param {import('p-defer').DeferredPromise<any>} options.onCall
+ * @param {(inCap: any) => boolean} [options.shouldFail]
+ */
+async function getService (options) {
+  const { aggregator } = await getAggregatorServiceCtx()
+  const aggregatorService = await getAggregatorServiceServer(aggregator.raw, {
+    onCall: (invCap) => {
+      options.onCall.resolve(invCap)
+    },
+    shouldFail: options.shouldFail
+  })
+  const issuer = getServiceSigner(aggregator)
+  const audience = aggregatorService.connection.id
+  /** @type {import('@web3-storage/filecoin-client/types').InvocationConfig} */
+  const invocationConfig = {
+    issuer,
+    audience,
+    with: issuer.did(),
+  }
+
+  return {
+    invocationConfig,
+    aggregatorService
+  }
+}
+
+/**
+ * @param {number} length 
+ * @param {number} size 
+ */
+async function getPieces (length, size) {
+  const pieces = await randomCargo(length, size)
+
+  const pieceRecords = await Promise.all(pieces.map(p => encodePiece(p)))
+  return {
+    pieces,
+    pieceRecords
+  }
+}
+
+/**
+ * @param {{ link: import("@web3-storage/data-segment").PieceLink }} piece
+ */
+async function encodePiece (piece) {
+  const storefront = 'did:web:web3.storage'
+  const group = 'did:web:free.web3.storage'
+  const pieceRow = {
+    piece: piece.link,
+    storefront,
+    group,
+    insertedAt: Date.now()
+  }
+
+  return pieceEncode.message(pieceRow)
+}

--- a/packages/core/test/workflow/piece-buffering.test.js
+++ b/packages/core/test/workflow/piece-buffering.test.js
@@ -14,7 +14,7 @@ import { createQueueClient } from '../../src/queue/client.js'
 
 import { bufferPieces } from '../../src/workflow/piece-buffering.js'
 
-test.beforeEach(async (t) => {
+test.before(async (t) => {
   const sqs = await createQueue()
 
   /** @type {import('@aws-sdk/client-sqs').Message[]} */
@@ -51,7 +51,7 @@ test.afterEach(async t => {
 test('can buffer received pieces', async t => {
   const { s3, sqsClient, queueUrl, queuedMessages } = t.context
   const bucketName = await createBucket(s3)
-  const { pieces, pieceRecords } = await getPieces(100, 128)
+  const { pieces, pieceRecords } = await getPieces()
 
   const storeClient = createBucketStoreClient(s3, {
     name: bucketName,
@@ -66,16 +66,11 @@ test('can buffer received pieces', async t => {
   const bufferPiecesResp = await bufferPieces({
     storeClient,
     queueClient,
-    records: pieceRecords.map((pr, index) => ({
-      body: pr,
-      id: `${index}`
-    })),
-    // we cannot get elasticmq to be FIFO with SQS create command
-    disableMessageGroupId: true
+    pieceRecords,
   })
   t.truthy(bufferPiecesResp.ok)
   t.falsy(bufferPiecesResp.error)
-  t.is(bufferPiecesResp.ok?.countSuccess, pieces.length)
+  t.is(bufferPiecesResp.ok, pieces.length)
 
   // Validate message received to queue
   await pWaitFor(() => queuedMessages.length === 1)
@@ -94,91 +89,9 @@ test('can buffer received pieces', async t => {
   }
 })
 
-test('can buffer received pieces with different groups', async t => {
-  const { s3, sqsClient, queueUrl, queuedMessages } = t.context
-  const storefronts = [
-    'did:web:web.storage',
-    'did:web:nft.storage'
-  ]
-  const bucketName = await createBucket(s3)
-  const {
-    pieces: piecesStorefrontA,
-    pieceRecords: pieceRecordsStorefrontA, 
-  } = await getPieces(50, 128, {
-    storefront: storefronts[0]
-  })
-  const {
-    pieces: piecesStorefrontB,
-    pieceRecords: pieceRecordsStorefrontB
-  } = await getPieces(50, 128, {
-    storefront: storefronts[1]
-  })
-
-  const storeClient = createBucketStoreClient(s3, {
-    name: bucketName,
-    encodeRecord: bufferEncode.storeRecord,
-    decodeRecord: bufferDecode.storeRecord,
-  })
-  const queueClient = createQueueClient(sqsClient, {
-    queueUrl,
-    encodeMessage: bufferEncode.message,
-  })
-
-  const bufferPiecesResp = await bufferPieces({
-    storeClient,
-    queueClient,
-    records: [...pieceRecordsStorefrontA, ...pieceRecordsStorefrontB].map((pr, index) => ({
-      body: pr,
-      id: `${index}`
-    })),
-    // we cannot get elasticmq to be FIFO with SQS create command
-    disableMessageGroupId: true
-  })
-  t.truthy(bufferPiecesResp.ok)
-  t.falsy(bufferPiecesResp.error)
-  t.is(bufferPiecesResp.ok?.countSuccess, [...piecesStorefrontA, ...piecesStorefrontB].length)
-
-  // Validate message received to queue
-  await pWaitFor(() => queuedMessages.length === 2)
-
-  // Storefront message 0
-  const bufferRef0 = await bufferDecode.message(queuedMessages[0].Body || '')
-  const getBufferRes0 = await storeClient.get(
-    `${bufferRef0.cid}/${bufferRef0.cid}`
-  )
-  t.truthy(getBufferRes0.ok)
-  t.falsy(getBufferRes0.error)
-
-  const piecesStorefrontMessage0 = getBufferRes0.ok?.storefront === storefronts[0] ? piecesStorefrontA : piecesStorefrontB
-  t.is(getBufferRes0.ok?.pieces.length, piecesStorefrontMessage0.length)
-
-  for (const bufferedPiece of getBufferRes0.ok?.pieces || []) {
-    t.truthy(
-      piecesStorefrontMessage0.find(piece => piece.link.equals(bufferedPiece.piece))
-    )
-    t.is(bufferedPiece.policy, 0)
-  }
-
-  // Storefront message 1
-  const bufferRef1 = await bufferDecode.message(queuedMessages[1].Body || '')
-  const getBufferRes1 = await storeClient.get(
-    `${bufferRef1.cid}/${bufferRef1.cid}`
-  )
-  t.truthy(getBufferRes1.ok)
-  t.falsy(getBufferRes1.error)
-
-  const piecesStorefrontMessage1 = getBufferRes1.ok?.storefront === storefronts[0] ? piecesStorefrontA : piecesStorefrontB
-  t.is(getBufferRes1.ok?.pieces.length, piecesStorefrontB.length)
-
-  for (const bufferedPiece of getBufferRes1.ok?.pieces || []) {
-    t.truthy(piecesStorefrontMessage1.find(piece => piece.link.equals(bufferedPiece.piece)))
-    t.is(bufferedPiece.policy, 0)
-  }
-})
-
 test('fails buffering received pieces if fails to store', async t => {
   const { sqsClient, queueUrl } = t.context
-  const { pieceRecords } = await getPieces(100, 128)
+  const { pieceRecords } = await getPieces()
 
   const storeClient = {
     put: () => {
@@ -196,11 +109,7 @@ test('fails buffering received pieces if fails to store', async t => {
     // @ts-expect-error 
     storeClient,
     queueClient,
-    records: pieceRecords.map((pr, index) => ({
-      body: pr,
-      id: `${index}`
-    })),
-    disableMessageGroupId: true
+    pieceRecords,
   })
   t.falsy(bufferPiecesResp.ok)
   t.truthy(bufferPiecesResp.error)
@@ -210,7 +119,7 @@ test('fails buffering received pieces if fails to store', async t => {
 test('fails buffering received pieces if fails to queue', async t => {
   const { s3 } = t.context
   const bucketName = await createBucket(s3)
-  const { pieceRecords } = await getPieces(100, 128)
+  const { pieceRecords } = await getPieces()
 
   const storeClient = createBucketStoreClient(s3, {
     name: bucketName,
@@ -229,28 +138,17 @@ test('fails buffering received pieces if fails to queue', async t => {
     storeClient,
     // @ts-expect-error adapted queue
     queueClient,
-    records: pieceRecords.map((pr, index) => ({
-      body: pr,
-      id: `${index}`
-    })),
-    disableMessageGroupId: true
+    pieceRecords,
   })
   t.falsy(bufferPiecesResp.ok)
   t.truthy(bufferPiecesResp.error)
   t.is(bufferPiecesResp.error?.name, QueueOperationErrorName)
 })
 
-/**
- * @param {number} length
- * @param {number} size
- * @param {object} [opts]
- * @param {string} [opts.storefront]
- * @param {string} [opts.group]
- */
-async function getPieces (length, size, opts = {}) {
-  const pieces = await randomCargo(length, size)
+async function getPieces () {
+  const pieces = await randomCargo(100, 128)
 
-  const pieceRecords = await Promise.all(pieces.map(p => encodePiece(p, opts)))
+  const pieceRecords = await Promise.all(pieces.map(p => encodePiece(p)))
   return {
     pieces,
     pieceRecords
@@ -259,13 +157,10 @@ async function getPieces (length, size, opts = {}) {
 
 /**
  * @param {{ link: import("@web3-storage/data-segment").PieceLink }} piece
- * @param {object} [opts]
- * @param {string} [opts.storefront]
- * @param {string} [opts.group]
  */
-async function encodePiece (piece, opts = {}) {
-  const storefront = opts.storefront || 'did:web:web3.storage'
-  const group = opts.group || 'did:web:free.web3.storage'
+async function encodePiece (piece) {
+  const storefront = 'did:web:web3.storage'
+  const group = 'did:web:free.web3.storage'
   const pieceRow = {
     piece: piece.link,
     storefront,

--- a/packages/functions/src/processor/piece-add.js
+++ b/packages/functions/src/processor/piece-add.js
@@ -1,0 +1,99 @@
+import * as Sentry from '@sentry/serverless'
+import { Config } from 'sst/node/config'
+
+import { getServiceConnection, getServiceSigner } from '@w3filecoin/core/src/service.js'
+import { createQueueClient } from '@w3filecoin/core/src/queue/client'
+import { encode } from '@w3filecoin/core/src/data/piece.js'
+import { addPieces } from '@w3filecoin/core/src/workflow/piece-add'
+
+import { mustGetEnv } from '../utils.js'
+
+Sentry.AWSLambda.init({
+  environment: process.env.SST_STAGE,
+  dsn: process.env.SENTRY_DSN,
+  tracesSampleRate: 1.0,
+})
+
+/**
+ * Get EventRecord from the SQS Event triggering the handler.
+ * The event contains a batch of `piece`s provided from producer.
+ * These pieces should be added using `piece/add` and propagated for piece buffering.
+ *
+ * @param {import('aws-lambda').SQSEvent} sqsEvent
+ */
+async function pieceAddWorkflow (sqsEvent) {
+  const { queueClient } = getProps()
+  const { aggregatorDid, aggregatorUrl } = getEnv()
+  const { PRIVATE_KEY: privateKey } = Config
+
+  const aggregatorServiceConnection = getServiceConnection({
+    did: aggregatorDid,
+    url: aggregatorUrl
+  })
+  const issuer = getServiceSigner({
+    did: aggregatorDid,
+    privateKey
+  })
+  /** @type {import('@web3-storage/filecoin-client/types').InvocationConfig} */
+  const invocationConfig = {
+    issuer,
+    audience: aggregatorServiceConnection.id,
+    with: issuer.did(),
+  }
+
+  const records = sqsEvent.Records.map(r => ({
+    body: r.body,
+    id: r.messageId
+  }))
+
+  const { ok, error } = await addPieces({
+    queueClient,
+    aggregatorServiceConnection,
+    invocationConfig,
+    records,
+  })
+
+  if (error) {
+    return {
+      statusCode: 500,
+      body: error.message
+    }
+  }
+
+  return {
+    statusCode: 200,
+    body: ok.countSuccess,
+    // to retry failed items from batch
+    batchItemFailures: ok.batchItemFailures
+  }
+}
+
+/**
+ * Get props clients
+ */
+function getProps () {
+  const { pieceBufferQueueUrl, pieceBufferQueueRegion } = getEnv()
+
+  return {
+    queueClient: createQueueClient({
+      region: pieceBufferQueueRegion
+    }, {
+      queueUrl: pieceBufferQueueUrl,
+      encodeMessage: encode.message,
+    })
+  }
+}
+
+/**
+ * Get Env validating it is set.
+ */
+function getEnv () {
+  return {
+    pieceBufferQueueUrl: mustGetEnv('PIECE_BUFFER_QUEUE_URL'),
+    pieceBufferQueueRegion: mustGetEnv('PIECE_BUFFER_QUEUE_REGION'),
+    aggregatorDid: mustGetEnv('AGGREGATOR_DID'),
+    aggregatorUrl: mustGetEnv('AGGREGATOR_URL'),
+  }
+}
+
+export const workflow = Sentry.AWSLambda.wrapHandler(pieceAddWorkflow)

--- a/packages/functions/src/processor/piece-buffering.js
+++ b/packages/functions/src/processor/piece-buffering.js
@@ -23,15 +23,14 @@ Sentry.AWSLambda.init({
  */
 async function pieceBufferringWorkflow (sqsEvent) {
   const { storeClient, queueClient } = getProps()
-  const records = sqsEvent.Records.map(r => ({
-    body: r.body,
-    id: r.messageId
-  }))
+  const pieceRecords = sqsEvent.Records.map(r => r.body)
+  const groupId = sqsEvent.Records[0].attributes.MessageGroupId || 'did:web:web3.storage'
 
   const { ok, error } = await bufferPieces({
     storeClient,
     queueClient,
-    records
+    pieceRecords,
+    groupId
   })
 
   if (error) {

--- a/stacks/api-stack.js
+++ b/stacks/api-stack.js
@@ -16,7 +16,7 @@ export function ApiStack({ app, stack }) {
   setupSentry(app, stack)
 
   const {
-    pieceQueue,
+    pieceAddQueue,
     privateKey
   } = use(ProcessorStack)
 
@@ -39,12 +39,13 @@ export function ApiStack({ app, stack }) {
           BROKER_DID: process.env.BROKER_DID ?? '',
           BROKER_URL: process.env.BROKER_URL ?? '',
           UCAN_LOG_URL: process.env.UCAN_LOG_URL ?? '',
-          PIECE_QUEUE_URL: pieceQueue.queueUrl,
+          PIECE_QUEUE_URL: pieceAddQueue.queueUrl,
           PIECE_QUEUE_REGION: stack.region
         },
         bind: [
           privateKey,
-          ucanLogBasicAuth
+          ucanLogBasicAuth,
+          pieceAddQueue
         ]
       }
     },


### PR DESCRIPTION
In the context of work in [integration PR](https://github.com/web3-storage/w3filecoin/pull/47), extracted two larger fixes I ended up making, so that we have aggregator fully functional.

### aggregate add self invocation

1. `#main` implementation was incomplete. It would handle `aggregate/queue` invocations from storefront, where queue consumer would propagate given `piece` to `buffer` queue.
2.  while this would allow the piece to be buffered, and eventually aggregated and queued for the dealer, we were not storing  the pieces in the `piece-store`. Which we previously discussed as critical to store everything as it gets in the system and out of the system. In addition, we rely on this to avoid duplicates and generate the needed receipts.
3. therefore, a new pre processing queue was added, where the self invocation of `aggregate/add` happens (store to the store the aggregate), and we propagate then the event for the buffering queue system. This workflow is called `piece-add` given its goal is to invoke the `piece-add` 

### standard queue grouping

- discovered on testing that `messageGroupId` only works for FIFO queue. [See](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_SendMessage.html#API_SendMessage_RequestSyntax) in section "MessageGroupId"
  - removed message group ID being sent
